### PR TITLE
디스코드 봇 업데이트 20250902

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,7 +38,9 @@ try:
     else:
         NEXON_API_RUN_ENV = 'LIVE'
     NEXON_API_KEY: str = os.getenv(f'NEXON_API_TOKEN_{NEXON_API_RUN_ENV}', None)
+    NEOPLE_API_KEY: str = os.getenv(f'NEOPLE_API_TOKEN_{NEXON_API_RUN_ENV}', None)
     NEXON_API_HOME: str = os.getenv('NEXON_API_HOME')
+    NEOPLE_API_HOME: str = os.getenv('NEOPLE_API_HOME')
 # Nexon Open API 키를 제대로 불러오지 못하면 실행 불가
 except BotConfigFailed as e:
     print(f"Failed loading Nexon API key!!: {e}")
@@ -78,7 +80,7 @@ NEXON_API_REFRESH_INTERVAL: int = 15  # minutes
 # Bot 시작 시간 기록
 BOT_START_TIME_STR: str = kst_format_now()
 BOT_START_DT: datetime = datetime.strptime(BOT_START_TIME_STR, '%Y-%m-%d %H:%M:%S')
-BOT_VERSION: str = f"v20250822-{BOT_TOKEN_RUN}"
+BOT_VERSION: str = f"v20250902-{BOT_TOKEN_RUN}"
 
 # 디버그 모드 설정
 if BOT_TOKEN_RUN == 'dev':

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ intents.message_content = True
 
 bot = commands.Bot(command_prefix='븜 ', intents=intents, help_command=None)
 # 디버그용 명령어
-@bot.command(name="debug")
+@bot.command(name="디버그")
 async def bot_debug(ctx: commands.Context, arg: str = None):
     if arg == "mem":
         await deb_command.deb_memory_usage(ctx)
@@ -72,19 +72,37 @@ async def run_api_sunday_notice(ctx: commands.Context):
 async def run_api_ability_info(ctx: commands.Context, character_name: str):
     await api_command.api_ability_info(ctx, character_name)
 
+@bot.command(name="운세")
+async def run_api_maple_fortune_today(ctx: commands.Context, character_name: str):
+    await api_command.api_maple_fortune_today(ctx, character_name)
+
 @bot.command(name="날씨")
 async def run_api_weather(ctx: commands.Context, location: str):
     await api_command.api_weather_v1(ctx, location)
+
+@bot.command(name="던파정보")
+async def run_api_dnf_characters(ctx: commands.Context, server_name: str, character_name: str):
+    await api_command.api_dnf_characters(ctx, server_name, character_name)
 
 # 명령어 등록 from service.stk_command
 @bot.command(name="미국주식")
 async def run_stk_us_stock(ctx: commands.Context, ticker: str):
     await stk_command.stk_us_stock_price(ctx, ticker)
 
+# 븜 help, 븜 도움말 -> 븜 명령어 리다이렉트
+@bot.command(name="help")
+async def run_msg_handle_help_redirection(ctx: commands.Context):
+    await msg_command.msg_handle_help_redirection(ctx)
+
+@bot.command(name="도움말")
+async def run_msg_handle_help_redirection(ctx: commands.Context):
+    await msg_command.msg_handle_help_redirection(ctx)
+
 @bot.event
 async def on_message(message: discord.Message):
     # 봇 명령어 처리
     await bot.process_commands(message)
+    
 
 # 봇 실행!
 bot.run(str(BOT_TOKEN))

--- a/save-images.sh
+++ b/save-images.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+IMAGE_NAME="discord-bot-img"
+TODAY_DATE=$(date +%Y%m%d)
+
+if [ "$(docker ps -aq -f name=$CONTAINER_NAME)" ]; then
+  echo "기존 컨테이너가 존재하여 종료 및 삭제진행"
+  docker stop $CONTAINER_NAME || true
+  docker rm $CONTAINER_NAME || true
+fi
+
+echo "이미지 초기화"
+if docker image inspect $IMAGE_NAME > /dev/null 2>&1; then
+  echo "기존 이미지가 존재하여 삭제진행"
+  docker rmi $IMAGE_NAME || true
+fi
+
+echo "도커 이미지 빌드 중..."
+docker build -t $IMAGE_NAME .
+
+echo "도커 이미지 저장 중..."
+docker save -o "./temp/${IMAGE_NAME}-${TODAY_DATE}.tar" $IMAGE_NAME

--- a/service/api_exception.py
+++ b/service/api_exception.py
@@ -45,7 +45,223 @@ class NexonAPIOCIDNotFound(NexonAPIError):
     def __init__(self, message: str = "Nexon API에서 OCID를 찾을 수 없어양"):
         super().__init__(message)
         self.message = message
-        
+
+class NeopleAPIError(BotBaseException):
+    """Neople API 사용 중 발생하는 오류"""
+    pass
+
+class NeopleAPIKeyMissing(NeopleAPIError):
+    """Neople API Key 미입력 (API000)"""
+    def __init__(self, message: str = "네오플 API 키가 입력되지 않거나 잘못되었어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIInvalidId(NeopleAPIError):
+    """Neople API 유효하지 않은 게임아이디 (API001)"""
+    def __init__(self, message: str = "유효하지 않은 게임아이디를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPILimitExceed(NeopleAPIError):
+    """Neople API 요청 제한 초과 (API002)"""
+    def __init__(self, message: str = "네오플 API 요청 제한을 초과했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIInvalidAPIkey(NeopleAPIError):
+    """Neople API 잘못된 API 키 (API003)"""
+    def __init__(self, message: str = "유효하지 않은 API 키를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIBlockedAPIKey(NeopleAPIError):
+    """Neople API 차단된 API 키 (API004)"""
+    def __init__(self, message: str = "차단된 네오플 API 키를 사용하고 있어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIWrongGameKey(NeopleAPIError):
+    """Neople API 잘못된 게임 키 (API005)"""
+    def __init__(self, message: str = "다른 게임의 네오플 API를 호출했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIInvalidParams(NeopleAPIError):
+    """Neople API 잘못된 파라미터 (API006)"""
+    def __init__(self, message: str = "잘못된 API 요청 파라미터를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIClientSocketError(NeopleAPIError):
+    """Neople API 클라이언트 소켓 오류 (API007)"""
+    def __init__(self, message: str = "네오플 API와 통신 중에 오류가 발생했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIInvalidURL(NeopleAPIError):
+    """Neople API 잘못된 URL (API900)"""
+    def __init__(self, message: str = "잘못된 API 요청 URL을 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPIInvalidRequestParams(NeopleAPIError):
+    """Neople API 잘못된 요청 파라미터 (API901)"""
+    def __init__(self, message: str = "잘못된 API 요청 파라미터를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleAPISystemError(NeopleAPIError):
+    """Neople API 시스템 오류 (API999)"""
+    def __init__(self, message: str = "네오플 API 시스템 오류가 발생했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidServerID(NeopleAPIError):
+    """Neople API 유효하지 않은 서버 ID (DNF000)"""
+    def __init__(self, message: str = "잘못된 서버명(ID)를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidCharacterInfo(NeopleAPIError):
+    """Neople API 유효하지 않은 캐릭터 정보 (DNF001)"""
+    def __init__(self, message: str = "잘못된 캐릭터 정보를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidItemInfo(NeopleAPIError):
+    """Neople API 유효하지 않은 아이템 정보 (DNF003)"""
+    def __init__(self, message: str = "잘못된 아이템 정보를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidAuctionInfo(NeopleAPIError):
+    """Neople API 유효하지 않은 경매장 정보 (DNF004)"""
+    def __init__(self, message: str = "잘못된 경매장 정보를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidSkillInfo(NeopleAPIError):
+    """Neople API 유효하지 않은 스킬 정보 (DNF005)"""
+    def __init__(self, message: str = "잘못된 스킬 정보를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidTimelineParams(NeopleAPIError):
+    """Neople API 유효하지 않은 타임라인 검색 시간 파라미터 (DNF006)"""
+    def __init__(self, message: str = "타임라인을 불러오는데 문제가 발생했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFSearchAuctionItemOptionException(NeopleAPIError):
+    """Neople API 경매장 아이템 검색 갯수 제한 (DNF007)"""
+    def __init__(self, message: str = "경매장 아이템 검색 갯수 제한에 걸렸어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFSearchAuctionMultipleItemOptionException(NeopleAPIError):
+    """Neople API 다중 아이템 검색 갯수 제한 (DNF008)"""
+    def __init__(self, message: str = "다중 아이템 검색 갯수 제한에 걸렸어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFSearchAvatarMarketOptionException(NeopleAPIError):
+    """Neople API 아바타 마켓 검색 갯수 제한 (DNF009)"""
+    def __init__(self, message: str = "아바타 마켓 검색 갯수 제한에 걸렸어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidURL(NeopleAPIError):
+    """Neople API 유효하지 않은 URL (DNF900)"""
+    def __init__(self, message: str = "잘못된 API 요청 URL을 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFInvalidRequestParams(NeopleAPIError):
+    """Neople API 유효하지 않은 요청 파라미터 (DNF901)"""
+    def __init__(self, message: str = "잘못된 API 요청 파라미터를 입력했어양"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFSystemMaintenance(NeopleAPIError):
+    """Neople API 서비스 점검중 (DNF980)"""
+    def __init__(self, message: str = "던파 서비스 점검 중이에양!"):
+        super().__init__(message)
+        self.message = message
+
+class NeopleDNFSystemError(NeopleAPIError):
+    """Neople API 시스템 오류 (DNF999)"""
+    def __init__(self, message: str = "던파 API 시스템 오류가 발생했어양"):
+        super().__init__(message)
+        self.message = message
+
+def neople_api_error_handler(error_code: str) -> None:
+    """Neople API 오류 처리 함수
+
+    Args:
+        error_code (str): Neople API 오류 코드
+
+    Raises:
+        NeopleAPIError: Neople API 오류
+
+    Returns:
+        No return
+    """
+    if not isinstance(error_code, str):
+        raise NeopleAPIError("Invalid Neople API error code")
+    else:
+        error_code = error_code.strip().upper()
+
+    # Neople API 오류 로직처리
+    if "API000" in error_code:
+        raise NeopleAPIKeyMissing(error_code)
+    elif "API001" in error_code:
+        raise NeopleAPIInvalidId(error_code)
+    elif "API002" in error_code:
+        raise NeopleAPILimitExceed(error_code)
+    elif "API003" in error_code:
+        raise NeopleAPIInvalidAPIkey(error_code)
+    elif "API004" in error_code:
+        raise NeopleAPIBlockedAPIKey(error_code)
+    elif "API005" in error_code:
+        raise NeopleAPIWrongGameKey(error_code)
+    elif "API006" in error_code:
+        raise NeopleAPIInvalidParams(error_code)
+    elif "API007" in error_code:
+        raise NeopleAPIClientSocketError(error_code)
+    elif "API900" in error_code:
+        raise NeopleAPIInvalidURL(error_code)
+    elif "API901" in error_code:
+        raise NeopleAPIInvalidRequestParams(error_code)
+    elif "API999" in error_code:
+        raise NeopleAPISystemError(error_code)
+    elif "DNF000" in error_code:
+        raise NeopleDNFInvalidServerID(error_code)
+    elif "DNF001" in error_code:
+        raise NeopleDNFInvalidCharacterInfo(error_code)
+    elif "DNF003" in error_code:
+        raise NeopleDNFInvalidItemInfo(error_code)
+    elif "DNF004" in error_code:
+        raise NeopleDNFInvalidAuctionInfo(error_code)
+    elif "DNF005" in error_code:
+        raise NeopleDNFInvalidSkillInfo(error_code)
+    elif "DNF006" in error_code:
+        raise NeopleDNFInvalidTimelineParams(error_code)
+    elif "DNF007" in error_code:
+        raise NeopleDNFSearchAuctionItemOptionException(error_code)
+    elif "DNF008" in error_code:
+        raise NeopleDNFSearchAuctionMultipleItemOptionException(error_code)
+    elif "DNF009" in error_code:
+        raise NeopleDNFSearchAvatarMarketOptionException(error_code)
+    elif "DNF900" in error_code:
+        raise NeopleDNFInvalidURL(error_code)
+    elif "DNF901" in error_code:
+        raise NeopleDNFInvalidRequestParams(error_code)
+    elif "DNF980" in error_code:
+        raise NeopleDNFSystemMaintenance(error_code)
+    elif "DNF999" in error_code:
+        raise NeopleDNFSystemError(error_code)
+    else:
+        raise NeopleAPIError(f"Unknown Neople API error code: {error_code}")
 
 class KakaoAPIError(BotBaseException):
     """Kakao API 사용 중 발생하는 오류"""

--- a/service/api_utils.py
+++ b/service/api_utils.py
@@ -1,4 +1,6 @@
+import hashlib
 import math
+import random
 import requests
 import io
 import re
@@ -9,54 +11,48 @@ from pytz import timezone
 from config import NEXON_API_HOME, NEXON_API_KEY # NEXON OPEN API
 from config import KKO_LOCAL_API_KEY, KKO_API_HOME # KAKAO Local API
 from config import WTH_DATA_API_KEY, WTH_API_HOME # Weather API
+from config import NEOPLE_API_KEY, NEOPLE_API_HOME # Neople Developers API
 from service.api_exception import *
 
-from typing import Optional, Dict, List
+from typing import Optional, Dict, List, Tuple
 
 
-def general_request_error_handler(response: requests.Response) -> None:
-    """Nexon Open API의 일반적인 요청 오류를 처리하는 함수  
-    특수한 오류가 있는 경우를 제외하고, 일반적인 오류에 대한 예외를 발생시킴  
-    예외 처리 기준은 아래 Reference 링크를 참고
+def general_request_handler_neople(request_url: str, headers: Optional[dict] = None, params: Optional[dict] = None) -> dict:
+    """Neople API의 일반적인 요청을 처리하는 함수
 
     Args:
-        res (requests.Response): 요청 응답 객체
+        request_url (str): 요청할 URL
+        headers (Optional[dict], optional): 요청 헤더 (기본값 None)
+        params (Optional[dict], optional): 요청 파라미터 (기본값 None)
+
+    Returns:
+        dict: 응답 데이터
 
     Raises:
-        Exception: 요청 오류에 대한 예외를 발생시킴
+        Exception: 요청 오류에 대한 예외를 발생
 
     Reference:
-        https://openapi.nexon.com/ko/game/maplestory/?id=14
+        https://developers.neople.co.kr/contents/guide/pages/all  
+        Neople API의 경우 response_status마다 세부적인 error_code가 존재
     """
-    response_status_code: str = str(response.status_code)
-    exception_msg_prefix: str = f"{response_status_code} : "
-    response_data: dict = response.json()
-    exception_msg: dict = response_data.get('error')
-    if response.status_code == 400:
-        default_exception_msg = "Bad Request"
-        exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
-        raise NexonAPIBadRequest(exception_msg)
-    elif response.status_code == 403:
-        default_exception_msg = "Forbidden"
-        exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
-        raise NexonAPIForbidden(exception_msg)
-    elif response.status_code == 429:
-        default_exception_msg = "Too Many Requests"
-        exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
-        raise NexonAPITooManyRequests(exception_msg)
-    elif response.status_code == 500:
-        default_exception_msg = "Internal Server Error"
-        exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
-        raise NexonAPIServiceUnavailable(exception_msg)
+    if headers is None:
+        headers = {
+            "apikey": f"{NEOPLE_API_KEY}",
+        }
+
+    response: requests.Response = requests.get(url=request_url, headers=headers)
+
+    if response.status_code != 200:
+        response_data: dict = response.json()
+        error_data: dict = response_data.get('error', {})
+        neople_api_error_code: str = str(error_data.get('code', 'Unknown'))
+        neople_api_error_handler(error_code=neople_api_error_code)
     else:
-        if not exception_msg.get('message'):
-            raise NexonAPIError
-        else :
-            exception_msg = f"{exception_msg_prefix}{exception_msg.get('message')}"
-            raise NexonAPIError(exception_msg)
+        response_data: dict = response.json()
+        return response_data
 
 
-def general_request_handler(request_url: str, headers: Optional[dict] = None) -> dict:
+def general_request_handler_nexon(request_url: str, headers: Optional[dict] = None) -> dict:
     """Nexon Open API의 일반적인 요청을 처리하는 함수  
     요청 URL과 헤더를 받아서 GET 요청을 수행하고, 응답 데이터를 반환함
 
@@ -74,11 +70,37 @@ def general_request_handler(request_url: str, headers: Optional[dict] = None) ->
         headers = {
             "x-nxopen-api-key": NEXON_API_KEY,
         }
-    
-    response = requests.get(url=request_url, headers=headers)
-    
+
+    response: requests.Response = requests.get(url=request_url, headers=headers)
+
+    # general_request_error_handler 함수 통합 (2025.09.01)
     if response.status_code != 200:
-        general_request_error_handler(response)
+        response_status_code: str = str(response.status_code)
+        exception_msg_prefix: str = f"{response_status_code} : "
+        response_data: dict = response.json()
+        exception_msg: dict = response_data.get('error')
+        if response.status_code == 400:
+            default_exception_msg = "Bad Request"
+            exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
+            raise NexonAPIBadRequest(exception_msg)
+        elif response.status_code == 403:
+            default_exception_msg = "Forbidden"
+            exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
+            raise NexonAPIForbidden(exception_msg)
+        elif response.status_code == 429:
+            default_exception_msg = "Too Many Requests"
+            exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
+            raise NexonAPITooManyRequests(exception_msg)
+        elif response.status_code == 500:
+            default_exception_msg = "Internal Server Error"
+            exception_msg = f"{exception_msg_prefix}{exception_msg.get('message', default_exception_msg)}"
+            raise NexonAPIServiceUnavailable(exception_msg)
+        else:
+            if not exception_msg.get('message'):
+                raise NexonAPIError
+            else :
+                exception_msg = f"{exception_msg_prefix}{exception_msg.get('message')}"
+                raise NexonAPIError(exception_msg)
     return response.json()
 
 
@@ -102,7 +124,7 @@ def get_ocid(character_name: str) -> str:
     service_url = f"/maplestory/v1/id"
     url_encode_name: str = quote(character_name)
     request_url = f"{NEXON_API_HOME}{service_url}?character_name={url_encode_name}"
-    response_data: dict = general_request_handler(request_url)
+    response_data: dict = general_request_handler_nexon(request_url)
     
     # 정상적으로 OCID를 찾았을 때
     ocid: str = str(response_data.get('ocid'))
@@ -127,7 +149,7 @@ def get_character_popularity(ocid: str) -> str:
     service_url = f"/maplestory/v1/character/popularity"
     request_url = f"{NEXON_API_HOME}{service_url}?ocid={ocid}"
     try:
-        response_data: dict = general_request_handler(request_url)
+        response_data: dict = general_request_handler_nexon(request_url)
         popularity: int = response_data.get('popularity', "몰라양")
         return popularity
     except NexonAPIError:
@@ -145,7 +167,7 @@ def get_character_ability_info(ocid: str) -> dict:
     """
     service_url = f"/maplestory/v1/character/ability"
     request_url = f"{NEXON_API_HOME}{service_url}?ocid={ocid}"
-    response_data: dict = general_request_handler(request_url)
+    response_data: dict = general_request_handler_nexon(request_url)
     return response_data
 
 
@@ -164,7 +186,7 @@ ABILITY_MAX_TABLE: Dict[str, Dict[str, int]] = {
     r"최대\sHP\s{n}\s증가": {"레전드리": 600, "유니크": 450, "에픽": 300, "레어": 150},
     r"최대\sMP\s{n}\s증가": {"레전드리": 600, "유니크": 450, "에픽": 300, "레어": 150},
     r"방어력\s{n}\s증가": {"레전드리": 400, "유니크": 300, "에픽": 200, "레어": 100},
-    r"버프\s지속시간\s{n}%\s증가": {"레전드리": 50, "유니크": 38, "에픽": 25, "레어": -1},
+    r"버프\s스킬의\s지속\s시간\s{n}%\s증가": {"레전드리": 50, "유니크": 38, "에픽": 25, "레어": -1},
     r"일반\s몬스터\s공격\s시\s데미지\s{n}%\s증가": {"레전드리": 10, "유니크": 8, "에픽": 5, "레어": 3},
     r"상태\s이상에\s걸린\s대상\s공격\s시\s데미지\s{n}%\s증가": {"레전드리": 10, "유니크": 8, "에픽": 5, "레어": -1},
     r"메소\s획득량\s{n}%\s증가": {"레전드리": 20, "유니크": 15, "에픽": 10, "레어": 5},
@@ -175,7 +197,7 @@ ABILITY_MAX_TABLE: Dict[str, Dict[str, int]] = {
     r"마력\s{n}\s증가": {"레전드리": 30, "유니크": 21, "에픽": 12, "레어": -1},
     r"크리티컬\s확률\s{n}%\s증가": {"레전드리": 30, "유니크": 20, "에픽": 10, "레어": -1},
     r"보스\s몬스터\s공격\s시\s데미지\s{n}%\s증가": {"레전드리": 20, "유니크": 10, "에픽": -1, "레어": -1},
-    r"{n}%\s확률로\s재사용\s대기시간이\s미적용": {"레전드리": 20, "유니크": 10, "에픽": -1, "레어": -1},
+    r"스킬\s사용\s시\s{n}%\s확률로\s재사용\s대기시간이\s미적용": {"레전드리": 20, "유니크": 10, "에픽": -1, "레어": -1},
     r"최대\sHP\s{n}%\s증가": {"레전드리": 20, "유니크": 10, "에픽": -1, "레어": -1},
     r"최대\sMP\s{n}%\s증가": {"레전드리": 20, "유니크": 10, "에픽": -1, "레어": -1},
     r"방어력의\s{n}%\s만큼\s데미지\s고정값\s증가": {"레전드리": 50, "유니크": 25, "에픽": -1, "레어": -1},
@@ -349,7 +371,7 @@ def get_notice(target_event: str = None) -> list[dict]:
     """
     service_url = f"/maplestory/v1/notice-event"
     request_url = f"{NEXON_API_HOME}{service_url}"
-    response_data: dict = general_request_handler(request_url)
+    response_data: dict = general_request_handler_nexon(request_url)
     notices: list = response_data.get('event_notice', [])
     if target_event is None:
         notice_filter = None
@@ -379,7 +401,7 @@ def get_notice_details(notice_id: str) -> dict:
     """
     service_url = f"/maplestory/v1/notice-event/detail"
     request_url = f"{NEXON_API_HOME}{service_url}?notice_id={notice_id}"
-    response_data: dict = general_request_handler(request_url)
+    response_data: dict = general_request_handler_nexon(request_url)
     return response_data
 
 
@@ -687,4 +709,331 @@ def process_weather_data(weather_data: dict) -> dict:
     return return_data
 
 
+def neople_dnf_server_parse(server_name: str) -> str:
+    """네오플 API 연동하여 dnf 서버 name - code 변환
 
+    Args:
+        server_name (str): dnf 서버 이름 (한글)
+
+    Returns:
+        str: dnf 서버 코드 (쿼리에 사용할 영어명)
+
+    Reference:
+        https://developers.neople.co.kr/contents/apiDocs/df
+    """
+    request_url = f"{NEOPLE_API_HOME}/df/servers?apikey={NEOPLE_API_KEY}"
+    response_data: dict = general_request_handler_neople(request_url)
+    
+    search_server_name = server_name.strip()
+    return_server_id: str = ""
+    dnf_server_list: List[dict] = response_data.get("rows", [])
+
+    # ServerId 조회
+    if dnf_server_list:
+        dnf_server_dict: dict = {}
+        for server in dnf_server_list:
+            server_name_kr = server.get("serverName", "")
+            server_name_en = server.get("serverId", "")
+            dnf_server_dict[server_name_kr] = server_name_en
+        return_server_id = dnf_server_dict.get(search_server_name, "")
+    else:
+        raise NeopleAPIError(f"던전앤파이터 서버 정보를 찾을 수 없어양")
+
+    # ServerId 조회를 못한 경우
+    if return_server_id == "":
+        raise NeopleAPIError(f"던파에 {search_server_name} 서버가 없어양")
+
+    return return_server_id
+
+
+def neople_dnf_get_character_id(server_name: str, character_name: str) -> str:
+    """던전앤파이터 캐릭터의 고유 ID를 가져오는 함수
+
+    Args:
+        server_name (str): 서버 이름
+        character_name (str): 캐릭터 이름
+
+    Returns:
+        str: 캐릭터 코드
+
+    Raises:
+        NeopleAPIError: API 호출 오류
+    """
+    server_id = neople_dnf_server_parse(server_name)
+    character_name = quote(character_name.strip())
+    request_url = f"{NEOPLE_API_HOME}/df/servers/{server_id}/characters?characterName={character_name}&apikey={NEOPLE_API_KEY}"
+    response_data: dict = general_request_handler_neople(request_url)
+    character_list: List[dict] = response_data.get("rows", [])
+    character_info = character_list[0] if character_list else None
+    if character_info:
+        character_code = character_info.get("characterId", "")
+        if character_code:
+            return character_code
+        else:
+            raise NeopleAPIError(f"모험가 정보를 찾는데 실패했어양...")
+    else:
+        raise NeopleAPIError(f"{server_name}서버 {character_name}모험가 정보를 찾을 수 없어양")
+    
+def _mix_seed(base_seed: int, f_cate: str, salt: str) -> int:
+    h = hashlib.md5(f"{base_seed}|{f_cate}|{salt}".encode('utf-8')).hexdigest()
+    return int(h, 16)
+
+def maple_pick_fortune(seed: int) -> str:
+    """메이플스토리 운세를 생성하는 함수
+
+    Args:
+        seed (int): 랜덤 시드 값
+
+    Returns:
+        str: 운세 결과
+    """
+    fortune_grade_table: Dict[int, Tuple[str, str]] = {
+        5: ("★★★★★", "대박"),
+        4: ("★★★★☆", "행운"),
+        3: ("★★★☆☆", "평온"),
+        2: ("★★☆☆☆", "주의"),
+        1: ("★☆☆☆☆", "폭망"),
+    }
+    fortune_grade_weights: List[Tuple[int, int]] = [
+        (5, 5),
+        (4, 20),
+        (3, 30),
+        (2, 40),
+        (1, 5),
+    ]
+    fortune_category: Dict[str, str] = {
+        "StarForce": "오늘의 스타포스 운세",
+        "Cube": "오늘의 큐브 운세",
+        "Boss": "오늘의 보스 운세",
+        "Cash": "오늘의 캐시 아이템 운세",
+        "DNF": "오늘의 던파 운세",
+    }
+    fortune_message : Dict[str, Dict[int, List[str]]] = {
+        "StarForce": {
+            5: ["오늘 운세가 매우 ㅆㅅㅌㅊ에양!!",
+                "오늘 엄청난 행운이 느껴져양! 지금 바로 스타포스 강화해양!",
+                "오늘은 한방에 ⭐22성 가기 좋은 날씨에양!",
+                "모두에게 장비를 자랑할 수 있는 절호의 기회에양!",
+                "용사님의 클라스를 보여줄 최고의 기회에양!!",
+                "온 우주가 스타포스 강화를 도와주는 날이에양!",
+                "행운의 여신이 용사님에게 미소를 짓는 날이에양!",
+                "눈감고 딸각 눌러도 성공하는 날이에양!!!",
+                "오늘 스타포스하고 저랑 신혼집 장만해양!!!🏩"],
+            4: ["오늘 운세가 ㅅㅌㅊ에양!",
+                "잘하면? 22성? 갈 수 있을것? 같아양!",
+                "오늘 스타포스 해보는게 어때양? 행운이 느껴져양!",
+                "별빛의 기운이 용사님을 도와줄거에양!⭐",
+                "여유있게 스타포스를 눌러보는게 어떨까양?",
+                "오늘은 제가 강화해도 성공하는 날이에양!",
+                "왠지 대박의 기운이 느껴져양. 성공하면 저한테 뽀찌주세양!🤑"],
+            3: ["오늘 운세가 그냥 ㅍㅌㅊ에양.",
+                "오늘은 무난한 날이에양. 스타포스도 무난하게 붙을거에양.",
+                "별(⭐) 일 없을 거에양.",
+                "스타포스 성공하거나 실패하거나 파괴되거나에양.",
+                "스타포스 겁나지 말고 눌러보세양.",
+                "아무일 없듯이 지나갈 거에양.",
+                "평범하게 스타포스 눌러보세양."],
+            2: ["오늘 운세가 ㅎㅌㅊ에양..",
+                "스타포스 누를 돈으로 저한테 맛있는거 사주세양!",
+                "오늘은 스타포스 누르지 않는게 좋겠어양...",
+                "💸스타포스 1조 클럽 가입하기 좋은 날이에양",
+                "안좋은 쪽으로 큰일이 일어날 것 같은 예감이 들어양...",
+                "스타포스 하다가 거지될 수도 있어양"],
+            1: ["오늘 운세가 ㅆㅎㅌㅊ에양 ㅋㅋ",
+                "장비를 정지... 켁 파괴됐어양!!!",
+                "스타포스 누르지도 않았는데 장비가 터졌어양!!!",
+                "돈 버리고 싶으면 스타포스 해보세양 ㅋㅋ",
+                "오늘은 진짜 레알로 스타포스 누르지 않는게 좋겠어양...",
+                "스타포스 누를 돈으로 맛있는거 사드세양!",
+                "오늘 스타포스하면 장비가 다 터져서 저처럼 벗고 다녀야 해양...🩲",
+                "메소를 스타포스 하는데 커녕 장비 복구하는데 다 쓰고 말거에양"]
+        },
+        "Cube": {
+            5: ["오늘 운세가 매우 ㅆㅅㅌㅊ에양!!",
+                "딸각 한번에 모든게 레전더리가 되는 날이에양!",
+                "오늘 애마삼/애공삼 오너가 되는 날이에양!",
+                "모두에게 개쩌는 잠재옵션을 보여주는 날이에양!",
+                "오늘은 모든게 레전더리가 되는 날이에양!",
+                "용사님의 이쁜 잠재옵션이 기대되양",
+                "왜 혼자서 미라클 타임을 즐기고 있어양?🌈",
+                "보보보, 드드드, 메메메의 냄새가 느껴져양!",],
+            4: ["오늘 운세가 ㅅㅌㅊ에양!",
+                "큐브의 신이 함께하는 날이에양",
+                "큐브의 신이 함께하는 날이에양",
+                "원하는 옵션이 그방 나올거에양",
+                "원하는 옵션이 그방 나올거에양",
+                "오늘 저랑 두줄 만들어봐양...❤️",
+                "오늘은 제가 돌려도 잘 나오는 날이에양!",
+                "오늘은 제가 돌려도 잘 나오는 날이에양!",
+                "왠지 대박의 기운이 느껴져양. 성공하면 저한테 뽀찌주세양!",
+                "왠지 대박의 기운이 느껴져양. 성공하면 저한테 뽀찌주세양!",
+                "이쁜 두줄이 나올 것 같아양!"],
+            3: ["오늘 운세가 그냥 ㅍㅌㅊ에양.",
+                "돌리다보면 괜찮은 옵션이 나올지도...♻️",
+                "무난하게 두줄을 노려봐양",
+                "오늘은 무난한 날이에양. 큐브도 무난하게 돌릴거에양.",
+                "이벤트 큐브 있어양?",
+                "이상한 옵션가지고 세줄이라하면 혼나양!",
+                "신중하게 생각해봐양"],
+            2: ["오늘 운세가 ㅎㅌㅊ에양..",
+                "하루 종일 잠재만 돌리다가 하루 다 갈거에양...",
+                "오늘은 큐브 돌리지 않는게 좋겠어양...",
+                "오늘은 두줄도 못 볼수도 있어양",
+                "등급이 오르기라도 하면 다행이에양",
+                "천장의 냄새가 나는 날이에양...",
+                "존버가 답이에양!!! 큐브를 최대한 아껴봐양"],
+            1: ["오늘 운세가 ㅆㅎㅌㅊ에양 ㅋㅋ",
+                "천장을 치고 엉엉 우는 모습이 보여양",
+                "오늘은 진짜 레알로 큐브하지 않는게 좋을것 같아양",
+                "스펙이 내려가지 않았다면 그걸로 다행이에양",
+                "천장 칠 메소는 가지고 계신거에양?💰",
+                "원하는 옵션 보지도 못할 거에양",
+                "큐브 아까워양..."]
+        },
+        "Boss": {
+            5: ["오늘 운세가 매우 ㅆㅅㅌㅊ에양!!",
+                "이번달 임대료는 낼 것 같아양!",
+                "오늘 주보 잡으면 엄청날 행운이 찾아올거에양!",
+                "설마 주보 다 잡은건 아니겠지양?",
+                "오늘 저랑 같이 주보 잡으러 가양!❤️",
+                "블링크빵 전승각이 보이는 날이에양!",
+                "오늘 보스가 겜 접는날이라고 템뿌린데양!",
+                "주보 다 잡으면 저랑같이... 꺅!!",
+                "오늘 주보 맛좋노",
+                "치킨점."],
+            4: ["오늘 운세가 ㅅㅌㅊ에양!",
+                "이번달 전기세는 낼 것 같아양!",
+                "오늘 보스 패턴이 이상해도 참아야해양!",
+                "어서 주보 잡으러 가세양!",
+                "얼른 도핑거리 사고 보스가양!",
+                "깨고 싶었던 보스가 바로 클리어?!"
+                "오늘 주보 맛좋겠누"],
+            3: ["오늘 운세가 ㅍㅌㅊ에양.",
+                "오늘 식비라도 나올거에양.",
+                "오늘도 뭐 그렇저럭 이에양",
+                "언제나 늘 칠흑이 안뜨는 법이에양",
+                "칠흑을 원한다면 다른날에 가는게 어때양?",
+                "오늘 반지상자라도 뜨면 좋겠어양",],
+            2: ["오늘 운세가 ㅎㅌㅊ에양..",
+                "사냥 하는게 더 좋을 수도 있어양...",
+                "오늘 태초의 정수도 못볼 수도 있어양",
+                "반빨별이라도 뜨면 다행이에양",
+                "보스 잡다가 실수 할 수도 있어양...",
+                "오늘은 그냥 사냥이나 하세양"],
+            1: ["오늘 운세가 ㅆㅎㅌㅊ에양 ㅋㅋ",
+                "오늘 블링크빵 전패할 수도 있어양",
+                "보스잡지 말고 사냥이나 하세양 ㅋㅋ",
+                "보스잡지 말고 븜미랑 데이트 어때양?",
+                "오늘 밥값도 안나올 수도 있어양...",
+                "온갖 억까를 당할 수도 있어양",
+                "오늘은 진짜 레알로 보스 안잡는게 좋을것 같아양",]
+        },
+        "Cash": {
+            5: ["오늘 운세가 매우 ㅆㅅㅌㅊ에양!!",
+                "지금 자석펫과 마라벨이 기다리고 있어양!",
+                "1등상이 그냥 짜잔하고 나오는 날이에양",
+                "마스터피스, 루나크리스탈 풀매수 하세양!",
+                "MVP작하고 오히려 돈이 남을수도 있어양!",
+                "오늘 아무거나 사도 좋으니 질러양!",
+                "븜미랑 도박하러 가양! 🎰🎰🎰",
+                "사장님이 미쳤어양",
+                "치킨점."],
+            4: ["오늘 운세가 ㅅㅌㅊ에양!",
+                "뽑기에서 좋은 게 나올 거에양!",
+                "뽑기 운이 좋은 날이에양!",
+                "MVP작하면 본전 볼수도 있겠어양!",
+                "🍎 플래티넘애플하기 좋은 날이에양",
+                "🍏 골든애플하기 좋은 날이에양",
+                "👑 로얄스타일하기 좋은 날이에양",
+                "🍓 원더베리하기 좋은 날이에양",
+                "MVP작하기 좋은 날이에양"],
+            3: ["오늘 운세가 ㅍㅌㅊ에양.",
+                "꼭 필요한 물건만 구매하세양!",
+                "무분별한 낭비는 떽!!! 이에양!",
+                "오늘은 무난하게 운이 좋을거에양",
+                "언제나 좋은건 잘 안뜨는 법이에양",
+                "매일 운이 좋을 수가 없어양",
+                "오늘은 별일 없을거에양",
+                "신중한 구매를 하세양"],
+            2: ["오늘 운세가 ㅎㅌㅊ에양..",
+                "충동적인 도박🎰은 하지마세양!",
+                "오늘은 뽑기하지 않는게 좋겠어양...",
+                "MVP작하면 손해볼 수도 있어양",
+                "폭망할 수도 있으니 조심해양"],
+            1: ["오늘 운세가 ㅆㅎㅌㅊ에양 ㅋㅋ",
+                "던파나 하러 가세양!",
+                "봉자나 까러 가세양! 🔐",
+                "개 폭망하는 미래가 보였어양!💥",
+                "오늘은 진짜 레알로 폭망할 것 같아양!💥",
+                "븜미랑 던파나 하러 가양",
+                "캐쉬샵 근처에도 가지마세양. 💀"]
+        },
+        "DNF": {
+            5: ["오늘 운세가 매우 ㅆㅅㅌㅊ에양!!",
+                "아라드가 위험해양! 지금당장 DNF 다운로드",
+                "오늘은 태거시를 먹는 날이에양",
+                "오늘은 태초악세를 먹는 날이에양",
+                "주간컨텐츠 하다가 좋은게 나올지도!",
+                "날씨를 잃은 큐브를 먹기 좋은 날이에양",
+                "기품을 잃은 향수를 먹기 좋은 날이에양",
+                "븜미랑 데이트하기 좋은 날씨에양",
+                "종말의 숭배자에서 태초 쌍란을 볼 수 있어양!",
+                "지금 당장 봉자🔐 까러 가야해양!!!"],
+            4: ["오늘 운세가 ㅅㅌㅊ에양!",
+                "오늘 에픽을 마구마구 먹을 수도 있을거에양",
+                "공회전이 끝나는 날일수도 있어양!",
+                "오늘은 봉자하기 좋은 날씨에양",
+                "종말의 숭배자에서 더 큰 행운이 찾아올거에양!",
+                "오늘은 태초를 먹을 수도 있어양",
+                "귀여운 븜미를 만날 수도 있어양!"],
+            3: ["오늘 운세가 ㅍㅌㅊ에양.",
+                "언제나 똑같은 일이 일어날 거에양",
+                "공회전이 계속될 거에양...",
+                "늘 하던 던파랑 똑같아양",
+                "맨날 태초가 나올 순 없어양!",
+                "븜미도 태거시가 없어서 눈물나양!"],
+            2: ["오늘 운세가 ㅎㅌㅊ에양..",
+                "오늘은 간단하게 종말의 숭배자만 돌아양",
+                "오늘은 간단하게 환오요괴만 돌아양",
+                "패턴운이 안좋아서 폭망할수도 있어양",
+                "오늘 파밍던전 폭망할 수도 있어양",
+                "이상한 사람을 만날 수도 있어양",
+                "코디가 이상한 븜미를 만날 수도 있어양"],
+            1: ["오늘 운세가 ㅆㅎㅌㅊ에양 ㅋㅋ",
+                "메이플이나 하러 가야해양!",
+                "피로도가 아까워양...💀",
+                "오늘은 진짜 레알로 폭망할 것 같아양!💥",
+                "오늘은 던파하기 좋은 날이 아니에양...",
+                "던파 접으셈"]
+        }
+    }
+    def _pick_grade(rng: random.Random) -> int:
+        roll = rng.randint(1, 100)
+        acc = 0
+        for g, w in fortune_grade_weights:
+            acc += w
+            if roll <= acc:
+                return g
+        return -1
+    
+    fortune_result: List[str] = []
+    for f_cate, f_name in fortune_category.items():
+        # 행운 등급 결정
+        random_grade: random.Random = random.Random(_mix_seed(seed, f_cate, "grade"))
+        f_grade = _pick_grade(random_grade)
+
+        if f_grade != -1:
+            # 행운 메세지 결정
+            random_message: random.Random = random.Random(_mix_seed(seed, f_cate, "message"))
+            f_result_star, f_result_name = fortune_grade_table[f_grade]
+            f_fortune_message_dict: Dict[int, List[str]] = fortune_message.get(f_cate)
+            f_fortune_message: str = random_message.choice(f_fortune_message_dict.get(f_grade, []))
+            f_text = (
+                f"{f_name}\n"
+                f"{f_result_star} ({f_result_name}): {f_fortune_message}\n"
+            )
+        else:
+            f_text = f"{f_name}\n오늘의 운세를 알 수 없어양...\n"
+        fortune_result.append(f_text)
+
+    return "\n".join(fortune_result)

--- a/service/msg_command.py
+++ b/service/msg_command.py
@@ -126,6 +126,9 @@ async def msg_handle_image(ctx: commands.Context, search_term: str):
         Exception: 메세지 삭제 권한이 없거나, 메세지 삭제 실패시 발생
         Exception: 이미지 검색 API 호출 실패시 발생
         Warning: 이미지를 찾을 수 없을 때 발생
+    
+    Note:
+        검색 지역 일본(ja-jp)으로 변경 (2025.09.01)
     """
     command_prefix: str = "븜 이미지 "
 
@@ -142,7 +145,8 @@ async def msg_handle_image(ctx: commands.Context, search_term: str):
             results = ddgs.images(
                 query=image_search_keyword,
                 safesearch="off",
-                num_results=10,
+                region="ja-jp",
+                num_results=20,
             )
         except DDGSException as e:
             await ctx.message.channel.send(f"이미지 검색 사이트에 오류가 발생했어양...")
@@ -154,8 +158,10 @@ async def msg_handle_image(ctx: commands.Context, search_term: str):
     if not results:
         await ctx.message.channel.send("이미지를 찾을 수 없어양!!")
         return
+    else:
+        images = [r for r in results if "image" in r and "url" in r]
 
-    image_results = [r for r in results if "image" in r and "url" in r]
+    image_results = images[0:10]  # 최대 10개 이미지
     view_owner: discord.User = ctx.message.author
     view = ImageViewer(images=image_results, search_keyword=image_search_keyword, requester=view_owner)
     index_indicator: str = f"{view.current_index + 1}/{len(view.images)}"
@@ -195,6 +201,26 @@ async def msg_handle_blinkbang(ctx: commands.Context):
 
         await ctx.message.channel.send(f"{mention}님의 블링크빵 결과: {result}미터 만큼 날아갔어양! 💨💨💨")
 
+# "븜 명령어" 리다이렉트
+@log_command
+async def msg_handle_help_redirection(ctx: commands.Context):
+    """사용자에게 도움말을 리다이렉트하는 기능
+
+    Args:
+        ctx(commands.Context): 도움말 요청이 포함된 디스코드 메세지
+    """
+    # 봇 메시지 무시
+    if ctx.message.author.bot:
+        return
+
+    else:
+        # 리다이렉트 명령어 확인
+        await msg_handle_help(ctx)
+
+        # 리다이렉트 명령어 안내
+        mention = ctx.message.author.mention
+        await ctx.message.channel.send(f"{mention} '븜 명령어'를 입력하세양!")
+
 # 명령어 "븜 명령어" 사용
 @log_command
 async def msg_handle_help(ctx: commands.Context):
@@ -208,75 +234,89 @@ async def msg_handle_help(ctx: commands.Context):
     Returns:
         None: 사용법 안내 메시지를 채널에 전송
     """
-    command_prefix: str = "븜 명령어"
 
     if ctx.message.author.bot:
         return
 
-    if ctx.message.content.startswith(command_prefix):
-        embed_description: str = (
-            "봇 개발자: yhbird ([github.com](https://github.com/yhbird))\n"
-            "Data based on NEXON Open API\n"
-            "븜끼 봇 사용법을 알려드릴게양!\n"
-        )
-        embed = discord.Embed(
-            title=f"븜끼 사용설명서 ({BOT_VERSION})",
-            description=embed_description,
-            color=discord.Color.blue()
-        )
-        embed.add_field(
-            name="븜 이미지 <검색어>",
-            value="이미지를 검색해서 최대 10개의 이미지를 보여줍니다.\n(사용하는 검색엔진: https://duckduckgo.com/)\n***참고로, 야한건... 안돼양!!!***\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 따라해 <메세지>",
-            value="입력한 메세지를 그대로 따라합니다. \n*마크다운을 지원해양*\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 날씨 <지역명 혹은 주소> (v1)",
-            value="**[Kakao / 기상청 API 연동]**\n 해당 지역의 날씨 정보를 조회합니다. \n*주소를 입력하면 더 정확하게 나와양\n대신 누군가 찾아올수도...*\n"
-        )
-        embed.add_field(
-            name="븜 블링크빵",
-            value="랜덤한 자연수 1~100 랜덤 추출합니다. \n*결과는 날아간 거리로 보여줘양*\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 기본정보 <캐릭터 이름>",
-            value="**[Nexon OPEN API 연동]**\n 메이플스토리 캐릭터의 기본 정보를 조회합니다.\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 상세정보 <캐릭터 이름>",
-            value="**[Nexon OPEN API 연동]**\n 메이플스토리 캐릭터의 상세 정보를 조회합니다.\n*기본 정보보다 더 많은 정보를 제공해양*\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 피씨방",
-            value="**[Nexon OPEN API 연동]**\n 최근 피씨방 공지사항을 조회합니다.\n*이미지가 길쭉해서 좀 오래걸려양*\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 썬데이",
-            value="**[Nexon OPEN API 연동]**\n 썬데이 메이플 공지사항을 조회합니다.\n*매주 금요일 오전에 업데이트돼양*\n ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 미국주식 <티커>",
-            value="**[yahoo finance API 연동]**\n 미국 주식의 현재 가격을 조회합니다.\n*아직 실험중인 기능이에양*\n*참고) 티커: BRK.B -> BRK-B* ",
-            inline=False
-        )
-        embed.add_field(
-            name="븜 명령어",
-            value="명령어 목록을 표시합니다. \n*도움이 필요하면 언제든지 불러양!!*\n ",
-            inline=False
-        )
-        embed_footer:str = (
-            f"봇 이름: {ctx.guild.me.name}\n"
-            f"봇 버전: {BOT_VERSION}\n"
-            f"소스코드: https://github.com/yhbird/study-discord"
-        )
-        embed.set_footer(text=embed_footer)
-        await ctx.send(embed=embed)
+    embed_description: str = (
+        "봇 개발자: 크로아 마법사악 ([github.com](https://github.com/yhbird))\n"
+        "븜끼 봇 사용법을 알려드릴게양!\n"
+    )
+    embed = discord.Embed(
+        title=f"븜끼봇 명령어 목록이에양",
+        description=embed_description,
+        color=discord.Color.blue()
+    )
+    embed.add_field(
+        name="븜 이미지 <검색어>",
+        value="이미지를 검색해서 최대 10개의 이미지를 보여줍니다.\n(사용하는 검색엔진: https://duckduckgo.com/)\n***참고로, 야한건... 안돼양!!!***\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 따라해 <메세지>",
+        value="입력한 메세지를 그대로 따라합니다. \n*마크다운을 지원해양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 날씨 <지역명 혹은 주소> (v1)",
+        value="**[Kakao / 기상청 API]**\n 해당 지역의 날씨 정보를 조회합니다. \n*주소를 입력하면 더 정확하게 나와양\n대신 누군가 찾아올수도...*\n"
+    )
+    embed.add_field(
+        name="븜 블링크빵",
+        value="랜덤한 자연수 1~100 랜덤 추출합니다. \n*결과는 날아간 거리로 보여줘양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 기본정보 <캐릭터 이름>",
+        value="**[넥슨 API]**\n 메이플스토리 캐릭터의 기본 정보를 조회합니다.\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 상세정보 <캐릭터 이름>",
+        value="**[넥슨 API]**\n 메이플스토리 캐릭터의 상세 정보를 조회합니다.\n*기본 정보보다 더 많은 정보를 제공해양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 어빌리티 <캐릭터 이름>",
+        value="**[넥슨 API]**\n 메이플스토리 캐릭터의 어빌리티 정보를 조회합니다.\n*사용중인 어빌리티와 프리셋 정보를 제공해양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 운세 <캐릭터 이름>",
+        value="**[넥슨 API]**\n 오늘의 메이플스토리 캐릭터 운세를 조회합니다.\n*재미로만 봐주세양!!*\n*참고) 5성:5%, 4성:20%, 3성:30%, 2성:40%, 1성:5% 확률로 나와양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 피씨방",
+        value="**[넥슨 API]**\n 최근 피씨방 공지사항을 조회합니다.\n*이미지가 길쭉해서 좀 오래걸려양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 썬데이",
+        value="**[넥슨 API]**\n 썬데이 메이플 공지사항을 조회합니다.\n*매주 금요일 오전에 업데이트돼양*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 던파정보 <서버이름> <캐릭터이름>",
+        value="**[네오플 API]**\n 던전앤파이터 캐릭터의 정보를 조회합니다.\n*한글로 서버 이름과 캐릭터 이름을 입력해양*\n*참고) 븜 던파정보 카인 마법사악*\n ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 미국주식 <티커>",
+        value="**[yahoo finance]**\n 미국 주식의 현재 가격을 조회합니다.\n*아직 실험중인 기능이에양*\n*참고) 티커: BRK.B -> BRK-B* ",
+        inline=False
+    )
+    embed.add_field(
+        name="븜 명령어",
+        value="명령어 목록을 표시합니다. \n*도움이 필요하면 언제든지 불러양!!*\n ",
+        inline=False
+    )
+    embed_footer:str = (
+        f"봇 이름: {ctx.guild.me.name}\n"
+        f"봇 버전: {BOT_VERSION}\n"
+        f"소스코드: https://github.com/yhbird/study-discord\n"
+        "Data based on NEXON Open API\n"
+        "Powered by Neople Open API\n"
+    )
+    embed.set_footer(text=embed_footer)
+    await ctx.send(embed=embed)


### PR DESCRIPTION
## 작업내용

PR #20 - Neople Open API 추가, 도움말, 명령어 오류 수정

### 오류수정
- "븜 던파정보"에서 던담, dfgear 사이트 URL이 제대로 생성되지 않는 현상 수정
- "븜 어빌리티"에서 일부 옵션의 최대값이 표시되지 않는 현상 수정

### 유지보수
- "븜 명령어" 혼동을 방지하기 위한 리디렉션 명령어 추가 (븜 help, 븜 도움말)
- Neople Open API, Nexon Open API를 혼동하지 않도록 API 호출 함수 재정비 및 리팩토링 진행

### 기능 개선
- Neople Open API 연결 추가, 던전앤파이터 캐릭터 정보 조회 기능 추가 (븜 던파정보)
- 메이플 일일 운세 기능 추가 (븜 운세, 캐릭터이름+오늘날짜 시드 기반 랜덤 운세)

## 작업계획
- 착용중인 장비 정보를 조회할 수 있도록 연구
- 븜 던파정보에서 착용중인 세트장비의 포인트를 수집하는 방법 연구
- 관리자를 위한 디버그 명령어 추가 및 재정비 예정
- 날씨 API, 주식 API 업데이트 작업 진행 예정